### PR TITLE
Adopt "alternate"  method with pandas.read_csv

### DIFF
--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -732,7 +732,7 @@ class MesaData:
         if dbg:
             print("Scrubbing history...")
 
-        model_numbers = DataFrame(self.data["model_number"])
+        model_numbers = DataFrame(self.data("model_number"))
         kept_indices = model_numbers.drop_duplicates(keep="last").index
         
         if len(model_numbers) - len(kept_indices) == 0:

--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -239,12 +239,17 @@ class MesaData:
 
             self.bulk_names = file.readline().split(None, -1)
 
+            pos_0 = file.tell()
             data_elements = file.readline().split(None, -1)
+            pos_1 = file.tell()
+            pos_diff = pos_1 - pos_0 # length of data line 1
+
             data_types = self._get_dtype(self.bulk_names, data_elements)
 
             # rewind & read data
-            file.seek(0)
-            self.bulk_data = np.loadtxt(file, dtype=data_types, skiprows=MesaData.bulk_names_line)
+            file.seek(-pos_diff)
+            self.bulk_data = np.fromfile(file, dtype=data_types, sep=" ")
+            #self.bulk_data = np.loadtxt(file, dtype=data_types, skiprows=MesaData.bulk_names_line)
 
         self.header_data = dict(zip(self.header_names, header_data))
         self.remove_backups()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='mesa_reader',
     author_email='wolfwm@uwec.edu',
     license='MIT',
     packages=['mesa_reader'],
-    install_requires=['numpy'],
+    install_requires=['numpy', 'pandas'],
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
It appears that `pandas.read_csv` is leagues faster than `np.loadtxt` and supports the same format argument; this appears to be the best way to do this without compiling a C/Fortran module. I also changed the remove_backups method to use the pandas `DataFrame.drop_duplicates()` method, as it drops the time required to accomplish that substantially.